### PR TITLE
Add MailKite MCP (Communication & Collaboration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**25 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-25-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-11-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)
@@ -223,6 +223,11 @@ _No entries yet_
 
 - **Offers:** Email infrastructure for AI agents — provision inboxes on demand, send and receive email, manage concurrent threads, custom domains, structured extraction on inbound mail, and SMS. Built for agents, not humans — no SMTP config, no Gmail wrappers.
 - **Access:** API key auth via `COMMUNE_API_KEY`. Install: `uvx commune-mcp`
+
+#### [MailKite MCP](https://mailkite.dev/docs/ai-agents)
+
+- **Offers:** Give any AI agent its own real email inbox — receive email as structured tool calls and send from a verified domain. Tools for send, inbound routes, webhooks, domains, templates, and message search.
+- **Access:** Hosted remote MCP at `https://mcp.mailkite.dev/mcp` with OAuth 2.0 authentication. No local install.
 
 ### Media & Content
 


### PR DESCRIPTION
Adds **MailKite MCP** under **Communication & Collaboration**, after Commune, and bumps the server count 24 → 25 (text marker + badge).

**Offers:** give any AI agent its own real email inbox — receive email as structured tool calls and send from a verified domain. Tools for send, inbound routes, webhooks, domains, templates, and message search.

**Access:** hosted remote MCP at `https://mcp.mailkite.dev/mcp` with OAuth 2.0. Zero setup, no local install — connect with just the URL.