### PR TITLE
Add UIZZE hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ _No entries yet_
 
 #### [UIZZE](https://uizze.com)
 
-- **Offers:** UI reference research, design contracts, validation, audits, and critiques that help Codex avoid generic AI UI output; also supports Claude Code and Cursor
-- **Access:** Paid UIZZE account required. Create a bearer token in Agent Connector and connect to the Streamable HTTP endpoint at `https://uizze.com/mcp`
+- **Offers:** A free anti-ui-slop Skill and deterministic `check_ui_slop` preview for coding agents. Full UIZZE adds live research across 800,000+ real web and iOS screens, product-specific design contracts, validation, audits, and rendered critique.
+- **Access:** Use the free, no-account Streamable HTTP preview at `https://uizze.com/mcp/preview`. It exposes `check_ui_slop`; install the local Skill with `npx skills add https://uizze.com --skill anti-ui-slop`. Full UIZZE is available at `https://uizze.com/mcp`.
 
 ### Knowledge & Memory
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ _No entries yet_
 
 #### [UIZZE](https://uizze.com)
 
-- **Offers:** A free anti-ui-slop Skill and deterministic `check_ui_slop` preview for coding agents. Full UIZZE adds live research across 800,000+ real web and iOS screens, product-specific design contracts, validation, audits, and rendered critique.
-- **Access:** Use the free, no-account Streamable HTTP preview at `https://uizze.com/mcp/preview`. It exposes `check_ui_slop`; install the local Skill with `npx skills add https://uizze.com --skill anti-ui-slop`. Full UIZZE is available at `https://uizze.com/mcp`.
+- **Offers:** Focused UI references and hosted design materials for coding agents across 800,000+ real web and iOS screens.
+- **Access:** Use the authenticated Streamable HTTP endpoint at `https://uizze.com/mcp` with a UIZZE agent token. Free local skills are available from the [canonical repository](https://github.com/uizze/uizze).
 
 ### Knowledge & Memory
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ _No entries yet_
 - **Offers:** Multi-model AI brainstorming — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs
 - **Access:** Streamable HTTP endpoint at `https://mcp.roundtable.now/mcp`. See [GitHub](https://github.com/sinaneshat/roundtable-dashboard) for more details
 
+#### [UIZZE](https://uizze.com)
+
+- **Offers:** UI reference research, design contracts, validation, audits, and critiques that help Codex avoid generic AI UI output; also supports Claude Code and Cursor
+- **Access:** Paid UIZZE account required. Create a bearer token in Agent Connector and connect to the Streamable HTTP endpoint at `https://uizze.com/mcp`
+
 ### Knowledge & Memory
 
 #### [Supermemory MCP](https://mcp.supermemory.ai/)


### PR DESCRIPTION
## Fit

- UIZZE runs as a maintained Streamable HTTP MCP server.
- It exposes `find_ui_references` and `find_ui_materials` for focused references and hosted design materials.
- The entry states the bearer-token requirement and links the free local skills separately.
- The service link has no affiliate or tracking parameters.

## Verification

- https://uizze.com returns HTTP 200
- https://uizze.com/mcp is the production endpoint
- `git diff --check` passes

This PR changes one README entry.