### PR TITLE
Add OpenPost to Marketing & CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ _No entries yet_
 - **Offers:** Customer support and engagement functionality through Fin, Intercom's AI agent
 - **Access:** OAuth authentication with your Intercom account required
 
+#### [OpenPost](https://openpost.social)
+
+- **Offers:** Social publishing tools for inspecting workspaces and media, preparing destination-specific content, validating posts, and scheduling or publishing through one visible queue
+- **Access:** Connect to `https://app.openpost.social/mcp` over Streamable HTTP with OAuth 2.0, or use the `/mcp` endpoint on a self-hosted OpenPost instance. See the [MCP guide](https://docs.openpost.social/mcp/)
+
 #### [Tally MCP](https://developers.tally.so/api-reference/mcp)
 
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ _No entries yet_
 - **Offers:** Customer support and engagement functionality through Fin, Intercom's AI agent
 - **Access:** OAuth authentication with your Intercom account required
 
-#### [OpenPost](https://openpost.social)
+#### [OpenPost](https://openpo.st)
 
 - **Offers:** Social publishing tools for inspecting workspaces and media, preparing destination-specific content, validating posts, and scheduling or publishing through one visible queue
-- **Access:** Connect to `https://app.openpost.social/mcp` over Streamable HTTP with OAuth 2.0, or use the `/mcp` endpoint on a self-hosted OpenPost instance. See the [MCP guide](https://docs.openpost.social/mcp/)
+- **Access:** Connect to `https://app.openpo.st/mcp` over Streamable HTTP with OAuth 2.0, or use the `/mcp` endpoint on a self-hosted OpenPost instance. See the [MCP guide](https://docs.openpo.st/mcp/)
 
 #### [Tally MCP](https://developers.tally.so/api-reference/mcp)
 


### PR DESCRIPTION
Adds OpenPost's hosted Streamable HTTP MCP endpoint to Marketing & CRM, including OAuth access and the equivalent self-hosted endpoint.

Disclosure: I maintain OpenPost.