### PR TITLE
Add DomScan hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ _No entries yet_
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
 
+#### [DomScan MCP](https://domscan.net/mcp-domain-checker)
+
+- **Offers:** Domain availability, DNS, WHOIS/RDAP, TLS, subdomain, valuation, email-authentication, and brand-monitoring tools
+- **Access:** Connect to `https://domscan.net/mcp` with Streamable HTTP and authenticate through OAuth discovery or a DomScan API key
+
 ### Communication & Collaboration
 
 #### [Asana MCP](https://developers.asana.com/docs/using-asanas-model-control-protocol-mcp-server)


### PR DESCRIPTION
Adds DomScan under Search & Data Extraction.\n\nThe server is hosted at https://domscan.net/mcp, uses Streamable HTTP, and offers domain availability, DNS, WHOIS/RDAP, TLS, subdomain, valuation, email-authentication, and brand-monitoring tools. It supports OAuth discovery or API-key authentication and has a free monthly allowance.\n\nDisclosure: I maintain DomScan.