### PR TITLE
Add Brainiall TTS to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ _No entries yet_
 
 ### Media & Content
 
-_No entries yet_
+#### [Brainiall TTS](https://www.brainiall.com/en/apis/text-to-speech)
+
+- **Offers:** Hosted text-to-speech over MCP with 54 neural voices across nine languages, including Brazilian Portuguese; returns 24 kHz mono WAV audio.
+- **Access:** Connect to `https://api.brainiall.com/mcp/tts/mcp` over Streamable HTTP with `Authorization: Bearer <BRAINIALL_API_KEY>`. Usage is $0.008 per 1,000 characters; new accounts receive $10 in credits without a card.
 
 ### Payments & Commerce
 


### PR DESCRIPTION
Adds Brainiall TTS to the Media & Content category.

Fit against the contribution criteria:

- MCP server: registered as `com.brainiall/tts` in the official MCP Registry.
- Hosted/managed: remote Streamable HTTP endpoint; no local server required.
- Network-accessible: `https://api.brainiall.com/mcp/tts/mcp` with Bearer API-key authentication for metered usage.
- Actively maintained: the public MIT-licensed repository was updated on 2026-07-29.
- Documented: the official product page and repository describe access, tools, formats and pricing.
- Commercial disclosure: usage is $0.008 per 1,000 characters; signup includes $10 in credits without a card.

The entry uses one category, an official non-affiliate URL and no embedded credential.

Disclosure: submitted by BRAINIALL, the MCP publisher.
