### PR TITLE
Add dotsweep to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ _No entries yet_
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
 
+#### [dotsweep](https://dotsweep.com)
+
+- **Offers:** Domain availability across 1,200+ TLDs with the renewal price, the registry's minimum registration term, and who is eligible to register. An answer no registry confirmed is returned as `estimated`, never `available`, so a rate-limited or unreachable registry is never reported as free. Tools: `check_domains`, `whois`, `list_tlds`
+- **Access:** Public streamable HTTP endpoint at `https://dotsweep.com/mcp` — free, no account and no API key. Setup click-path at [dotsweep.com/setup](https://dotsweep.com/setup), reference at [dotsweep.com/docs](https://dotsweep.com/docs)
+
 ### Communication & Collaboration
 
 #### [Asana MCP](https://developers.asana.com/docs/using-asanas-model-control-protocol-mcp-server)


### PR DESCRIPTION
Adds **dotsweep** at the bottom of *Search & Data Extraction*, in the documented entry format.

Against the inclusion criteria:

- **Is an MCP server** — `check_domains`, `whois`, `list_tlds`.
- **Hosted/managed** — `https://dotsweep.com/mcp`. Nothing to download or run; it also works from the phone apps, where nothing can be installed.
- **Network-accessible** — streamable HTTP.
- **Actively maintained** — CI runs the live endpoint on every push.
- **Documented** — [docs](https://dotsweep.com/docs), a [setup click-path](https://dotsweep.com/setup), and [/llms.txt](https://dotsweep.com/llms.txt).
- **Pricing** — free, no account and no API key, so there is nothing to declare.

What it does that a plain WHOIS lookup does not: it carries the **renewal** price rather than only the first-year promo, the registry's **minimum registration term** (`.ai` cannot be bought for a single year, so its real first bill is double the advertised figure), and the registry's **eligibility rules**. An answer no registry confirmed comes back `estimated` rather than `available` — a throttled registry reads like a not-found over WHOIS, and that is the one wrong answer that costs somebody a name.

Disclosure: I maintain this server.