### PR TITLE
Add OptionsAhoy (Finance & Crypto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+#### [OptionsAhoy](https://optionsahoy.com)
+
+- **Offers:** Equity compensation planning tools: multi-year incentive stock option (ISO) exercise schedules with alternative minimum tax (AMT) calculations, non-qualified stock option (NSO) exercise math, restricted stock unit (RSU) sell-vs-hold and lot ordering, sale planning toward a cash goal, qualified small business stock (QSBS) qualification checks, single-stock concentration analysis, and hedge pricing, with federal, 50-state, and DC tax calculations
+- **Access:** Connect to `https://optionsahoy.com/mcp` via Streamable HTTP. Free, no authentication or API key required
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
Hosted MCP server, Streamable HTTP at https://optionsahoy.com/mcp, no auth or key needed, so it meets the hosted/network-accessible criteria. 8 tools for equity-compensation planning (ISO/AMT exercise schedules, NSO, RSU, QSBS, concentration, hedging) backed by federal + 50-state + DC tax math. Docs: https://optionsahoy.com/for-agents and https://github.com/AlvisoOculus/optionsahoy-mcp (MIT).

Placed in the existing Finance & Crypto section (present in the README and TOC, though not yet in CONTRIBUTING's category list). Left the MCP_COUNT counter alone for the update workflow.