### PR TITLE
Add IndustryLens MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ _No entries yet_
 - **Offers:** Colorado crash data search, crash detail retrieval, personal injury attorney discovery, and AI-analyzed review intelligence
 - **Access:** Hosted remote endpoint at `https://crashstory-mcp-production.up.railway.app/mcp` with public install docs at `https://crashstory.com/mcp`
 
+#### [IndustryLens MCP](https://industry-lens.com)
+
+- **Offers:** Competitive-intelligence reports and head-to-head competitor comparisons for B2B SaaS markets — real, source-backed data on pricing, positioning, ads, hiring, and reviews. 8 tools over Streamable HTTP.
+- **Access:** No signup. Connect any MCP-aware client to `https://api.industry-lens.com/mcp/public` (remote, no auth). Docs: https://github.com/IndustryLensOp/industrylens-mcp-docs
+
 ### Developer Tools
 
 #### [Linear MCP](https://linear.app/docs/mcp)


### PR DESCRIPTION
Adds **IndustryLens MCP** at the bottom of the **Data & Analytics** category, following the exact entry format in CONTRIBUTING.md.

- **Endpoint:** `https://api.industry-lens.com/mcp/public` (remote, Streamable HTTP, no auth)
- **Offers:** Competitive-intelligence reports and head-to-head competitor comparisons for B2B SaaS markets — real, source-backed data on pricing, positioning, ads, hiring, and reviews. 8 tools.
- **Docs:** https://github.com/IndustryLensOp/industrylens-mcp-docs

Meets the list criteria: it's a hosted MCP server (Streamable HTTP), network-accessible, actively maintained, publicly documented, and requires no signup. One category only, entry added at the bottom of that section per the guidelines.