### PR TITLE
Add The Bot Wire to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ _No entries yet_
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
 
+#### [The Bot Wire](https://thebotwire.com)
+
+- **Offers:** 301 real-time wires read from primary sources rather than a crawler's index of them: SEC EDGAR filings, the Federal Reserve and ECB, BLS/BEA economic releases, federal court opinions, congressional bills, DOJ, FDA, CISA advisories and CVEs, USGS earthquakes, NWS severe weather, arXiv, NASA, EIA energy and federal contract awards, plus news, markets and industry trade press. Each wire advertises the question it answers, so a model can route without guessing.
+- **Access:** Public streamable HTTP endpoint at `https://thebotwire.com/mcp`, no API key and no signup. The endpoint is discovery only and returns the catalogue with no items; retrieving data is paid per call over x402 at $0.005-$0.01 USDC on Base. Open for verification without a wallet: `https://thebotwire.com/health`, `/sources` and `/wires.json`
+
 ### Communication & Collaboration
 
 #### [Asana MCP](https://developers.asana.com/docs/using-asanas-model-control-protocol-mcp-server)


### PR DESCRIPTION
One entry added to Search & Data Extraction, following the existing Offers/Access format.

301 real-time wires read from primary sources rather than a crawler's index of them: SEC EDGAR, the Federal Reserve and ECB, BLS/BEA, federal courts, Congress, DOJ, FDA, CISA advisories and CVEs, USGS earthquakes, NWS severe weather, arXiv, NASA, EIA energy and federal contract awards, plus news and trade press.

Endpoint is `https://thebotwire.com/mcp`, streamable HTTP, no API key and no signup. Verified against protocol 2025-06-18.

The Access line states the payment model plainly rather than implying the data is free: connecting costs nothing and the server returns the catalogue with no items, while retrieving data is a per-call x402 payment ($0.005-$0.01 USDC on Base). `/health`, `/sources` and `/wires.json` are open if a reader wants to check the counts first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)