### PR TITLE
Add Autoposting MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ _No entries yet_
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options
 - **Access:** Server available at `https://api.tally.so/mcp` with API key authentication required (`Authorization: Bearer tly-xxxx`). Get your API key from your Tally account
 
+#### [Autoposting MCP](https://autoposting.ai)
+
+- **Offers:** Draft, rewrite, schedule and publish social posts to X, LinkedIn, Instagram, Threads and YouTube, plus AI idea generation, carousel building, video clipping and knowledge base search (69 tools)
+- **Access:** Server available at `https://app.autoposting.ai/mcp` over Streamable HTTP with OAuth 2.1 Dynamic Client Registration, so no client ID or secret is needed. Sign in with your Autoposting account when the client prompts. Docs: https://docs.autoposting.ai/mcp/overview
+
 ### Search & Data Extraction
 
 #### [Apify Actors MCP](https://mcp.apify.com/)


### PR DESCRIPTION
Adds Autoposting at the bottom of Marketing & CRM.

Autoposting is a fully hosted MCP server — draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, manage brands and webhooks, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube (69 tools). Nothing to download or run locally.

- Endpoint: `https://app.autoposting.ai/mcp` — Streamable HTTP, OAuth 2.1 with Dynamic Client Registration (no client ID or secret to configure).
- Docs: https://docs.autoposting.ai/mcp/overview · Server card: https://app.autoposting.ai/.well-known/mcp/server-card.json
- Published in the official MCP registry as `ai.autoposting/autoposting`.
