### PR TITLE
Add AI Applyd MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**36 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-36-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-11-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ _No entries yet_
 - **Offers:** Multi-model AI brainstorming — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs
 - **Access:** Streamable HTTP endpoint at `https://mcp.roundtable.now/mcp`. See [GitHub](https://github.com/sinaneshat/roundtable-dashboard) for more details
 
+### Career & Job Search
+
+#### [AI Applyd](https://aiapplyd.com/mcps)
+
+- **Offers:** ATS resume scoring, job-description analysis, interview prep, cover letters, resume building and auto-apply that submits on the employer's own hiring system.
+- **Access:** Streamable HTTP endpoint at `https://mcp.aiapplyd.com/mcp` with OAuth 2.1 and dynamic client registration. See [GitHub](https://github.com/whateverneveranywhere/aiapplyd-mcp).
+
 ### Knowledge & Memory
 
 #### [Supermemory MCP](https://mcp.supermemory.ai/)


### PR DESCRIPTION
Adds **AI Applyd**, a hosted remote MCP server for job seekers.

- Repo: https://github.com/whateverneveranywhere/aiapplyd-mcp
- Endpoint: `https://mcp.aiapplyd.com/mcp` (Streamable HTTP, OAuth 2.1 + dynamic client registration)
- Also listed on the official MCP Registry (`io.github.whateverneveranywhere/aiapplyd`) and Smithery

Tools cover ATS resume scoring, job-description analysis, interview prep, cover letters, resume building and auto-apply. Every tool declares `readOnlyHint`/`destructiveHint`. Remote server, so there is nothing to install and no config file.

Formatted to match the surrounding entries.