### PR TITLE
Add Parallel Search MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**36 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-36-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-11-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)
@@ -206,6 +206,11 @@ _No entries yet_
 
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
+
+#### [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)
+
+- **Offers:** Hosted web search and page retrieval through `web_search` and `web_fetch`
+- **Access:** Connect directly to `https://search.parallel.ai/mcp` over Streamable HTTP; the default endpoint requires no authentication
 
 ### Communication & Collaboration
 


### PR DESCRIPTION
## Why it belongs

Parallel Search MCP is a managed remote server with public setup documentation and a stable Streamable HTTP URL. It fits the existing Search & Data Extraction category and can be used without authentication at the default endpoint.

## What changed

- add one entry at the bottom of Search & Data Extraction using the required Offers/Access format
- update both MCP counters to 36, the value produced by the repository's own `grep -c "^#### \\[.*\\]" README.md` workflow after this entry

## Validation

- live MCP `initialize` returned HTTP 200
- `tools/list` returned `web_search` and `web_fetch`
- verified heading count, marker count, and badge count are all 36
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.
