### PR TITLE
Add TraderSpy to Finance & Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+#### [TraderSpy](https://traderspy.app/mcp)
+
+- **Offers:** AI-generated crypto futures signals with entry, take-profit ladder and stop levels plus their realised outcomes; smart money positioning and an elite leaderboard across Binance, Hyperliquid, Bybit and OKX; live prices, OHLCV candles and 13 technical indicators; and the caller's own Hyperliquid balance, positions and distance to liquidation. All 15 tools are read-only — no order placement, withdrawal or transfer tool exists.
+- **Access:** Remote MCP server at `https://mcp.traderspy.app/mcp` (Streamable HTTP). OAuth 2.1 with dynamic client registration, or a free API key from https://traderspy.app/mcp sent as `Authorization: Bearer mcp_…`. `tools/list` is open, so the tool set is inspectable before connecting.
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
Adds **TraderSpy** under Finance & Crypto.

- **Endpoint:** `https://mcp.traderspy.app/mcp` (Streamable HTTP)
- **Auth:** OAuth 2.1 with dynamic client registration, or a free API key from
  <https://traderspy.app/mcp>. `initialize` and `tools/list` work without credentials, so the tool
  set is inspectable before connecting; tool calls require a key.
- **Tools:** 15, all read-only — AI signals with entry/target/stop and realised outcomes, smart money
  positioning across Binance, Hyperliquid, Bybit and OKX, an elite leaderboard, prices, candles, 13
  technical indicators, and the caller's own Hyperliquid account. No order placement, withdrawal or
  transfer tool exists.

Also in the official MCP Registry as `app.traderspy/traderspy` (DNS-verified namespace) and on
Smithery as `traderspy/traderspy`.

I left the server counter alone since `update-counter.yml` maintains it.