### PR TITLE
Add fmcg.network under Data & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ _No entries yet_
 
 ### Data & Analytics
 
+#### [fmcg.network](https://fmcg.network)
+
+- **Offers:** EU regulatory screening for consumer goods: allergen labelling, food additives and E numbers, health claims, nutrition declaration, date marking, cosmetics INCI and detergent labelling, plus supplier discovery
+- **Access:** Connect to `https://mcp.fmcg.network/mcp`, sign in via OAuth 2.1 with PKCE and dynamic client registration, no API key needed
+
 #### [Omnis Venture Intelligence MCP](https://www.bamboosnow.co/venture-intelligence-mcp-server)
 
 - **Offers:** Venture intelligence for autonomous agents with startup discovery, company scoring, diligence memo access, monitoring, and tenant-bound workspace automation


### PR DESCRIPTION
Adds fmcg.network, a remote MCP server for EU consumer goods regulatory data.

- **Endpoint:** `https://mcp.fmcg.network/mcp`
- **Auth:** OAuth 2.1 with PKCE and dynamic client registration, no API key
- **Section:** Data & Analytics, as domain data lookup rather than crawling or extraction

Nine capabilities across EU allergen labelling (Reg. 1169/2011 Annex II), additives and E numbers (Reg. 1333/2008), health claims (Reg. 1924/2006), nutrition declaration, date marking, cosmetics INCI (Reg. 1223/2009), detergent labelling (Reg. 648/2004), novel food, and supplier discovery.

Each answer quotes the register entry behind it, and a capability whose dataset is a partial extract of its register states that in the response so an unmatched term is not read as an all clear.

Public capability list, no auth needed: https://mcp.fmcg.network/capabilities
Also listed in the official MCP registry as `io.github.danielfrommunich/fmcg-network`.

Matched the two-bullet Offers/Access format used by the surrounding entries.