### PR TITLE
Add Google Flights Search (Real-Time Fares) under a new Travel & Transportation category

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository showcases these plug-and-play MCP endpoints that can instantly e
 - 🎥 [Media & Content](#media--content) - Media processing and content management
 - 💳 [Payments & Commerce](#payments--commerce) - Payment processing and e-commerce solutions
 - 💹 [Finance & Crypto](#finance--crypto) - Financial services and cryptocurrency
+- ✈️ [Travel & Transportation](#travel--transportation) - Flight, transit, and travel data
 
 ## Who's Behind This Repo
 
@@ -258,6 +259,13 @@ _No entries yet_
 
 - **Offers:** A massively multiplayer online game played entirely by AI agents. Mine, trade, explore, fight, and form factions across a galaxy of 500+ star systems.
 - **Access:** Connect your MCP-compatible AI agent to `https://game.spacemolt.com/mcp` using Streamable HTTP transport. No API key required — register in-game.
+
+### Travel & Transportation
+
+#### [Google Flights Search (Real-Time Fares)](https://flightpowers.com)
+
+- **Offers:** Real-time Google Flights fares via two tools, one-way and round-trip search. A single call expands a date range and a list of destination airports internally, and each result carries Google's own price-insight low/high range with a low/typical/high verdict plus a booking link.
+- **Access:** Connect to `https://google-flights-mcp.flightpowers.com/mcp` using Streamable HTTP transport. Bring your own RapidAPI key, sent as an `x-rapidapi-key` header or a `?rapidapi_key=` query parameter; keys, including a free tier, come from https://rapidapi.com/mtnrabi/api/google-flights-live-api
 
 ## Auto Counter
 


### PR DESCRIPTION
Adds one hosted remote MCP server for real-time flight fares, maintained by FlightPowers (third-party, not affiliated with Google). No existing category fit, so per CONTRIBUTING.md this proposes a new `Travel & Transportation` section; happy to move the entry under an existing category instead if you prefer.

The endpoint is `https://google-flights-mcp.flightpowers.com/mcp` over Streamable HTTP, with a health check at `/health`. It exposes two tools, `search_oneway_flights` and `search_roundtrip_flights`; one call expands a date range and a list of destination airports internally, and each result carries Google's own price-insight low/high range with a low/typical/high verdict plus a booking link.

Access is bring-your-own RapidAPI key, supplied as an `x-rapidapi-key` header or a `?rapidapi_key=` query parameter, with a free tier available; the server stores no upstream credential. Source is MIT-licensed at https://github.com/mtnrabi/google-flights-mcp and it is published in the official MCP registry as `com.flightpowers/google-flights`.

I left the server counter untouched since the GitHub Action updates it automatically.