### PR TITLE
Add Airport Lounge List

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**36 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-36-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-11-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)
@@ -206,6 +206,11 @@ _No entries yet_
 
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
+
+#### [Airport Lounge List](https://airportloungelist.com/mcp)
+
+- **Offers:** Search 8,500+ airport lounges worldwide and check which ones a credit card, membership, airline status or ticket class gets you into, with amenities, hours, terminal and reviews, plus network comparisons across Priority Pass, LoungeKey, DragonPass, Plaza Premium and Centurion
+- **Access:** Free. Streamable HTTP at `https://mcp.airportloungelist.com/mcp`; the eight lounge-data tools need no account, and OAuth 2.1 with dynamic client registration unlocks visit logging, reviews and a wishlist
 
 ### Communication & Collaboration
 


### PR DESCRIPTION
Adds one hosted MCP server, at the bottom of **Search & Data Extraction**.

#### [Airport Lounge List](https://airportloungelist.com/mcp)

- **Offers:** Search 8,500+ airport lounges worldwide and check which ones a credit card, membership, airline status or ticket class gets you into, with amenities, hours, terminal and reviews, plus network comparisons across Priority Pass, LoungeKey, DragonPass, Plaza Premium and Centurion
- **Access:** Free. Streamable HTTP at `https://mcp.airportloungelist.com/mcp`; the eight lounge-data tools need no account, and OAuth 2.1 with dynamic client registration unlocks visit logging, reviews and a wishlist

## Against the criteria

- **Is an MCP server** — 21 tools, each with MCP `title` and `annotations`; published to the official MCP registry as `com.airportloungelist.mcp/lounges`
- **Hosted/managed** — nothing to download or run; paste the URL
- **Network-accessible** — Streamable HTTP
- **Actively maintained** — operated by us, source repo at [Airport-Lounge-List/mcp-server](https://github.com/Airport-Lounge-List/mcp-server)
- **Documentation** — https://airportloungelist.com/mcp
- **Pricing** — free, rate limited per IP for anonymous callers

Verify with no credentials:

```bash
curl -s -X POST https://mcp.airportloungelist.com/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

## Two notes

**Category:** I picked Search & Data Extraction per the one-category rule, since this is fundamentally a searchable directory. There is no travel category — happy to move it if you would rather add one.

**Counter:** running `scripts/update-counter.sh` bumped the count from 24 to **36**. Only one of those is mine — the committed number was already stale by 11. The diff therefore touches the count line and the badge as well as my entry. Say the word if you would prefer I revert those two lines and leave the counter to you.