### PR TITLE
Add Magic Hour MCP to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ _No entries yet_
 
 ### Media & Content
 
-_No entries yet_
+#### [Magic Hour MCP](https://magichour.ai)
+
+- **Offers:** AI video, image, and audio generation and editing tools through a hosted MCP server
+- **Access:** Connect to `https://mcp.magichour.ai/` with a Magic Hour API key; see the [connection guide](https://github.com/magichourhq/magic-hour-mcp/blob/main/user.md) for OAuth and bearer-token setup
 
 ### Payments & Commerce
 


### PR DESCRIPTION
## Summary

- add Magic Hour as the first Media & Content entry
- document the hosted Streamable HTTP endpoint and authentication requirement
- link the official connection guide

Magic Hour is an actively maintained hosted MCP server with public documentation and source code.
