### PR TITLE
Add YG3 Marketing MCP to Marketing & CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ _No entries yet_
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options
 - **Access:** Server available at `https://api.tally.so/mcp` with API key authentication required (`Authorization: Bearer tly-xxxx`). Get your API key from your Tally account
 
+#### [YG3 Marketing MCP](https://www.yg3.ai/for-agents)
+
+- **Offers:** Marketing operations for AI agents across content and SEO, outbound email, LinkedIn, and paid ads, plus a site builder. 200+ tools.
+- **Access:** Server available at `https://mcp.yg3.ai/mcp`. Humans connect via OAuth at https://www.yg3.ai/connect. Agents can provision a sandbox workspace with one POST to `https://agency.yg3.ai/api/v1/workspaces` and use the returned Bearer token, no signup required. Free tier available.
+
 ### Search & Data Extraction
 
 #### [Apify Actors MCP](https://mcp.apify.com/)


### PR DESCRIPTION
Adds YG3 Marketing MCP at the bottom of the **Marketing & CRM** section, using the exact entry format from CONTRIBUTING.md.

Why it fits the list criteria:

- **Must be an MCP Server:** implements MCP, protocol version 2025-06-18. Live tool catalog at `https://mcp.yg3.ai/api/health`.
- **Must be hosted/managed:** fully hosted at `https://mcp.yg3.ai/mcp`. Nothing to download or run locally.
- **Network-accessible:** streamable HTTP transport.
- **Active maintenance:** actively developed, published to the official MCP registry as `io.github.YG3-ai/yg3-mcp`.
- **Documentation:** https://www.yg3.ai/for-agents and https://github.com/YG3-ai/yg3-mcp

**Pricing:** free tier available. Agents can provision a sandbox workspace with a single POST and no signup, so the server can be evaluated without an account. Sandbox workspaces are limited (no custom domain, no email sending, no ad spend, no social posting) and expire after 14 days unless claimed.

Only one category was chosen, and only one entry was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuUMcr8Rny6VVW5qUWjHJc