### PR TITLE
Add BulkPublish hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ _No entries yet_
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options
 - **Access:** Server available at `https://api.tally.so/mcp` with API key authentication required (`Authorization: Bearer tly-xxxx`). Get your API key from your Tally account
 
+#### [BulkPublish MCP](https://app.bulkpublish.com/docs)
+
+- **Offers:** Create, adapt, schedule, publish, and analyze social media content across connected channels for AI-agent workflows
+- **Access:** Streamable HTTP endpoint at `https://mcp.bulkpublish.com/mcp`; requires a BulkPublish account, API key, and connected channel permissions
+
 ### Search & Data Extraction
 
 #### [Apify Actors MCP](https://mcp.apify.com/)


### PR DESCRIPTION
Adds BulkPublish under Marketing & CRM as a hosted Streamable HTTP MCP server for AI-agent social media content workflows. Includes the official documentation URL, endpoint, capabilities, and authentication requirements. Link verified on 2026-09-02.