### PR TITLE
Add Motomarks hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,11 @@ _No entries yet_
 
 ### Media & Content
 
-_No entries yet_
+#### [Motomarks](https://motomarks.io/docs/mcp)
+
+- **Offers:** Hosted MCP access to a published automotive brand library: search brands, read brand metadata, and build normalized logo CDN URLs
+- **Access:** Streamable HTTP at `https://motomarks.io/api/mcp`. OAuth 2.1 in the browser, or a Motomarks API key. Free accounts are available; paid plans raise the daily request limit
+
 
 ### Payments & Commerce
 


### PR DESCRIPTION
## What

Adds Motomarks under Media & Content as a hosted MCP server.

- Official docs: https://motomarks.io/docs/mcp
- Endpoint: `https://motomarks.io/api/mcp` (streamable HTTP)
- Auth: OAuth 2.1 or a Motomarks API key. Free accounts are available; paid plans raise the daily request limit.

It matches the list criteria: hosted URL, no local install, documented access, and an official service page (not an affiliate link).