### PR TITLE
Add LiveDataLink remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ _No entries yet_
 - **Offers:** Colorado crash data search, crash detail retrieval, personal injury attorney discovery, and AI-analyzed review intelligence
 - **Access:** Hosted remote endpoint at `https://crashstory-mcp-production.up.railway.app/mcp` with public install docs at `https://crashstory.com/mcp`
 
+#### [LiveDataLink](https://livedatalink.ai)
+
+- **Offers:** 294 source-linked public-data tools across 60 domains, including government, markets, carrier safety, sanctions, courts, property, health, and energy. Supports task-specific tool groups; freshness and coverage vary by source.
+- **Access:** Hosted Streamable HTTP endpoint: `https://livedatalink.ai/mcp`. Anonymous evaluation is available. Get a bearer API key at https://livedatalink.ai/signup/free for 1,000 queries/month, no card. Paid plans start at $10/month.
+
 ### Developer Tools
 
 #### [Linear MCP](https://linear.app/docs/mcp)


### PR DESCRIPTION
Adds LiveDataLink at the bottom of Data & Analytics, following CONTRIBUTING.md's two-field format.

LiveDataLink is a maintained hosted Streamable HTTP MCP at https://livedatalink.ai/mcp, with 294 tools across 60 public-data domains, source/freshness context, and task-specific group filtering. Anonymous evaluation is supported; a free bearer key includes 1,000 queries/month, no card. Paid plans start at $10/month.

Validated September 8: anonymous initialize and tools/list succeed (294 tools); finance/courts filtering returns 45; the website, public distribution repo, and Glama connector resolve. Official registry identifier: io.github.blackboxfoundry/livedatalink.

Public docs: https://github.com/blackboxfoundry/livedatalink
Glama: https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink

This provides the ready-to-merge entry for the LiveDataLink submission emailed to MindPal earlier today. No existing entry or LiveDataLink PR was found. git diff --check passes.