### PR TITLE
Add Ryze AI MCP (Google Ads, Meta Ads, GA4, Search Console)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ _No entries yet_
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options
 - **Access:** Server available at `https://api.tally.so/mcp` with API key authentication required (`Authorization: Bearer tly-xxxx`). Get your API key from your Tally account
 
+#### [Ryze AI MCP](https://www.get-ryze.ai/how-to-connect-claude-to-google-meta-ads-mcp)
+
+- **Offers:** Google Ads, Meta Ads, GA4 and Google Search Console in one connector. Audit accounts, pull any report, keyword research, AI-referral traffic, plus approved write actions (pause, budget, negatives). Works in Claude, ChatGPT, Cursor, Claude Code and Grok
+- **Access:** Server at `https://connector.get-ryze.ai/mcp` with OAuth 2.1 (dynamic client registration + PKCE). Sign in with the Google or Facebook account that owns the ads; free
+
 ### Search & Data Extraction
 
 #### [Apify Actors MCP](https://mcp.apify.com/)

--- a/README.md
+++ b/README.md
@@ -185,10 +185,15 @@ _No entries yet_
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options
 - **Access:** Server available at `https://api.tally.so/mcp` with API key authentication required (`Authorization: Bearer tly-xxxx`). Get your API key from your Tally account
 
-#### [Ryze AI MCP](https://www.get-ryze.ai/how-to-connect-claude-to-google-meta-ads-mcp)
+#### [Google Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/google-ads-mcp)
 
-- **Offers:** Google Ads, Meta Ads, GA4 and Google Search Console in one connector. Audit accounts, pull any report, keyword research, AI-referral traffic, plus approved write actions (pause, budget, negatives). Works in Claude, ChatGPT, Cursor, Claude Code and Grok
-- **Access:** Server at `https://connector.get-ryze.ai/mcp` with OAuth 2.1 (dynamic client registration + PKCE). Sign in with the Google or Facebook account that owns the ads; free
+- **Offers:** Google Ads through MCP: account audits, search terms, GAQL reports, Keyword Planner ideas, recommendations, and approved changes to budgets, bids and negatives. MCC manager accounts supported
+- **Access:** Server at `https://connector.get-ryze.ai/mcp` with OAuth 2.1 (dynamic client registration + PKCE). Sign in with the Google account that owns the ads; no developer token; free
+
+#### [Meta Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/meta-ads-mcp)
+
+- **Offers:** Facebook and Instagram Ads through MCP: Insights by campaign, ad set and ad, creatives, lead forms, Meta Ad Library research, and approved changes to budgets and ad status
+- **Access:** Same server `https://connector.get-ryze.ai/mcp`, OAuth 2.1. Sign in with the Facebook user that has Business Manager access; no app review or token; free
 
 ### Search & Data Extraction
 

--- a/README.md
+++ b/README.md
@@ -185,15 +185,15 @@ _No entries yet_
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options
 - **Access:** Server available at `https://api.tally.so/mcp` with API key authentication required (`Authorization: Bearer tly-xxxx`). Get your API key from your Tally account
 
-#### [Google Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/google-ads-mcp)
+#### [Google Ads MCP by Ryze AI](https://www.get-ryze.ai/google-ads-mcp)
 
 - **Offers:** Google Ads through MCP: account audits, search terms, GAQL reports, Keyword Planner ideas, recommendations, and approved changes to budgets, bids and negatives. MCC manager accounts supported
-- **Access:** Server at `https://connector.get-ryze.ai/mcp` with OAuth 2.1 (dynamic client registration + PKCE). Sign in with the Google account that owns the ads; no developer token; free
+- **Access:** Server at `https://connector.get-ryze.ai/mcp` with OAuth 2.1 (dynamic client registration + PKCE). Sign in with the Google account that owns the ads; no developer token; free. Docs: https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/google-ads-mcp
 
-#### [Meta Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/meta-ads-mcp)
+#### [Meta Ads MCP by Ryze AI](https://www.get-ryze.ai/meta-ads-mcp)
 
 - **Offers:** Facebook and Instagram Ads through MCP: Insights by campaign, ad set and ad, creatives, lead forms, Meta Ad Library research, and approved changes to budgets and ad status
-- **Access:** Same server `https://connector.get-ryze.ai/mcp`, OAuth 2.1. Sign in with the Facebook user that has Business Manager access; no app review or token; free
+- **Access:** Same server `https://connector.get-ryze.ai/mcp`, OAuth 2.1. Sign in with the Facebook user that has Business Manager access; no app review or token; free. Docs: https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/meta-ads-mcp
 
 ### Search & Data Extraction
 


### PR DESCRIPTION
Adds Ryze AI to Marketing & CRM.

Hosted remote MCP at `https://connector.get-ryze.ai/mcp`, OAuth 2.1 with dynamic client registration and PKCE (metadata: https://connector.get-ryze.ai/.well-known/oauth-authorization-server). Connects Claude, ChatGPT, Cursor, Claude Code and Grok to the user's own Google Ads, Meta Ads, GA4 and Search Console. Read tools for audits, reports, keyword research and AI-referral traffic; write tools require approval in chat. Free to connect.

Listed in the official MCP registry as `io.github.irinabuht12-oss/google-meta-ads-ga4-mcp`. Repo: https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp