### PR TITLE
Add CareClinic Health Tracker hosted MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ _No entries yet_
 - **Offers:** Colorado crash data search, crash detail retrieval, personal injury attorney discovery, and AI-analyzed review intelligence
 - **Access:** Hosted remote endpoint at `https://crashstory-mcp-production.up.railway.app/mcp` with public install docs at `https://crashstory.com/mcp`
 
+#### [CareClinic Health Tracker](https://cdn.careclinic.io/mcp/help/index.html)
+
+- **Offers:** Review your own medication and supplement schedules, recent symptoms, mood, medication activity, and descriptive wellness summaries. Personal consumer use only, not clinical care or diagnosis. Medication writes are disabled.
+- **Access:** Remote Streamable HTTP at `https://mcp.careclinic.io/mcp`. Sign in to an active CareClinic account and consent through a supported client. OAuth 2.1 with S256 PKCE requires approved client identities and exact callbacks; no open Dynamic Client Registration. Free accounts can connect and receive basic summaries; extended trend detail requires CareClinic Premium. See the linked setup guide for health-data sharing, revocation, privacy, and support. Source is private.
+
 ### Developer Tools
 
 #### [Linear MCP](https://linear.app/docs/mcp)


### PR DESCRIPTION
CareClinic adds personal health tracking to MindPal's hosted MCP collection. The current Data & Analytics section covers venture and crash information. This entry gives readers a consumer-account option for reviewing their own recorded medication schedule, symptoms, mood, and descriptive wellness summaries.

The addition follows the existing Offers/Access format and goes at the bottom of Data & Analytics. CareClinic Software Inc. operates the remote Streamable HTTP endpoint, so users do not download a package or access its private source.

Authentication uses OAuth 2.1 with S256 PKCE. Approved client identities and exact registered callbacks are required. Open Dynamic Client Registration is not available. This is a directory submission, not a claim that the endpoint has been authenticated in MindPal or works with arbitrary MCP clients.

The contribution guide asks for pricing requirements: an active CareClinic consumer account can connect without Premium. Basic summaries are available on Free, and added trend detail requires CareClinic Premium. This access distinction is included in the entry because the guide explicitly requires it.

CareClinic is for personal consumer accounts, not clinical or HIPAA covered-entity use. It does not diagnose, recommend treatment, change medication instructions, or provide emergency care. Medication writes are disabled. Selected information is shared with the connected AI host after sign-in and consent, with the host's retention policy applying. Users can deny or revoke access. The entry links directly to the public setup and privacy guidance.

Validation on September 9, 2026:

- The public setup guide returned the supported features, sign-in flow, consent, revocation, consumer-use limits, and Free/Premium access distinction.
- The Official MCP Registry returned active version 0.2.0 for `io.careclinic/health-tracker` at `https://mcp.careclinic.io/mcp`.
- Public authorization metadata returned authorization-code and refresh-token grants, S256, and Client ID Metadata Document support. An unauthenticated initialize request returned HTTP 401 with its protected-resource metadata challenge. This proves discovery and access protection, not an authenticated end-user connection.
- The complete current README and repository issue/PR search contained no CareClinic entry or request. Only the requested entry is changed. The repository's counter workflow owns the generated count.

Public documentation: https://cdn.careclinic.io/mcp/help/index.html

Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.careclinic

OAuth metadata: https://mcp.careclinic.io/.well-known/oauth-authorization-server
